### PR TITLE
Enabling batch processing of files by adding wildcard support for input

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,12 @@ Make sure the required packages are installed using `pip install -r requirements
 
 ### Wildcard input (`-i`)
 
-The `-i` argument accepts a file path or a wildcard pattern (e.g. `connector_V00*.stl`). If the pattern matches multiple files and you do **not** provide `-o`, Tweaker processes each matched input independently and writes a separate output file per input:
+The `-i` argument accepts a file path or a wildcard pattern (e.g. `file_00*.stl`). If the pattern matches multiple files and you do **not** provide `-o`, Tweaker processes each matched input independently and writes a separate output file per input:
 
 - Default tweaking: `<basename>_tweaked.stl`
 - With `-c` (`--convert`): `<basename>_converted.stl`
+
+Please note that you need to use quotes if your filename contains a wildcard, e.g. `python Tweaker.py -i "file_00*.stl" -vb -x`.
 
 If you provide `-o` while your wildcard pattern matches multiple input files, Tweaker exits with an error:
 `Option '-o' cannot be used with a wildcard that matches multiple input files.`

--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@ Make sure the required packages are installed using `pip install -r requirements
 
 `python Tweaker.py -i demo_object.stl -vb`
 
+If you want to install this module as a CLI package install it via `pip`:
+
+    pip install git+https://github.com/ChristophSchranz/Tweaker-3.git
+    tweaker3 -i demo_object.stl 
+
 ### Wildcard input (`-i`)
 
 The `-i` argument accepts a file path or a wildcard pattern (e.g. `file_00*.stl`). If the pattern matches multiple files and you do **not** provide `-o`, Tweaker processes each matched input independently and writes a separate output file per input:
@@ -22,11 +27,6 @@ Please note that you need to use quotes if your filename contains a wildcard, e.
 
 If you provide `-o` while your wildcard pattern matches multiple input files, Tweaker exits with an error:
 `Option '-o' cannot be used with a wildcard that matches multiple input files.`
-
-If you want to install this module as a CLI package install it via `pip`:
-
-    pip install git+https://github.com/ChristophSchranz/Tweaker-3.git
-    tweaker3 -i demo_object.stl 
 
 ### Extended mode:
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,16 @@ Make sure the required packages are installed using `pip install -r requirements
 
 `python Tweaker.py -i demo_object.stl -vb`
 
+### Wildcard input (`-i`)
+
+The `-i` argument accepts a file path or a wildcard pattern (e.g. `connector_V00*.stl`). If the pattern matches multiple files and you do **not** provide `-o`, Tweaker processes each matched input independently and writes a separate output file per input:
+
+- Default tweaking: `<basename>_tweaked.stl`
+- With `-c` (`--convert`): `<basename>_converted.stl`
+
+If you provide `-o` while your wildcard pattern matches multiple input files, Tweaker exits with an error:
+`Option '-o' cannot be used with a wildcard that matches multiple input files.`
+
 If you want to install this module as a CLI package install it via `pip`:
 
     pip install git+https://github.com/ChristophSchranz/Tweaker-3.git

--- a/Tweaker.py
+++ b/Tweaker.py
@@ -4,6 +4,7 @@
 import sys
 import argparse
 import os
+import glob
 from time import time
 
 if __name__ == '__main__':
@@ -22,7 +23,8 @@ __version__ = "3.9, October 2020"
 def getargs():
     parser = argparse.ArgumentParser(description="Orientation tool for better 3D prints")
     parser.add_argument('-i ', action="store",
-                        dest="inputfile", help="select input file")
+                        dest="inputfile",
+                        help="select input file or wildcard pattern, e.g. 'connector_V00*.stl'")
     parser.add_argument('-o ', action="store", dest="outputfile", type=str,
                         help="select output file. '_tweaked' is postfix by default")
     parser.add_argument('-vb ', '--verbose', action="store_true", dest="verbose",
@@ -84,6 +86,10 @@ def getargs():
             filetype = "binarystl"
     arguments.output_type = filetype
     # print("Tweaker, arguments.output_type", arguments.output_type)
+    # Track whether the user explicitly provided an output file via CLI.
+    # This is needed to distinguish it from the automatically generated default.
+    arguments.outputfile_given = bool(arguments.outputfile)
+
     if arguments.outputfile:
         filetype = arguments.outputfile.split(".")[-1].lower()
         if filetype not in ["stl", "3mf", "obj"]:
@@ -121,7 +127,88 @@ demo object in verbose mode. Use argument -h for help.
 def cli():
     global FileHandler
     # Get the command line arguments. Run in IDE for demo tweaking.
-    stime = time()
+
+    def _process_single_file(input_path, args, fh):
+        """Process a single input file using existing Tweaker logic."""
+        stime = time()
+
+        # Determine output type and output file for this specific input
+        filetype = args.output_type if hasattr(args, "output_type") else None
+        if not filetype:
+            if "3mf" in os.path.splitext(input_path)[1]:
+                filetype = "3mf"
+            else:
+                filetype = "binarystl"
+        args.output_type = filetype
+
+        if args.outputfile:
+            # Keep existing behavior for explicitly provided outputfile
+            outputfile = args.outputfile
+        else:
+            if args.convert:
+                outputfile = os.path.splitext(input_path)[0] + "_converted"
+            else:
+                outputfile = os.path.splitext(input_path)[0] + "_tweaked"
+
+            if args.output_type == "3mf":
+                outputfile += ".3mf"  # TODO not supported yet
+            else:
+                outputfile += ".stl"
+
+        try:
+            objs = fh.load_mesh(input_path)
+            if objs is None:
+                sys.exit()
+        except (KeyboardInterrupt, SystemExit):
+            raise SystemExit("Error, loading mesh from file '{}' failed!".format(input_path))
+
+        # Start of tweaking.
+        if args.verbose:
+            print("Calculating the optimal orientation:\n  {}"
+                  .format(input_path.split(os.sep)[-1]))
+
+        info = dict()
+        for part, content in objs.items():
+            mesh = content["mesh"]
+            info[part] = dict()
+            if args.convert:
+                info[part]["matrix"] = [[1, 0, 0], [0, 1, 0], [0, 0, 1]]
+            else:
+                try:
+                    cstime = time()
+                    x = Tweak(mesh, args.extended_mode, args.verbose, args.show_progress, args.favside, args.volume)
+                    info[part]["matrix"] = x.matrix
+                    info[part]["tweaker_stats"] = x
+                except (KeyboardInterrupt, SystemExit):
+                    raise SystemExit("\nError, tweaking process for '{}' failed!".format(input_path))
+
+                # List tweaking results
+                if args.result or args.verbose:
+                    print("Result-stats for {}:".format(input_path.split(os.sep)[-1]))
+                    print(" Tweaked Z-axis: \t{}".format(x.alignment))
+                    print(" Axis {}, \tangle: {}".format(x.rotation_axis, x.rotation_angle))
+                    print(""" Rotation matrix: 
+            {:2f}\t{:2f}\t{:2f}
+            {:2f}\t{:2f}\t{:2f}
+            {:2f}\t{:2f}\t{:2f}""".format(x.matrix[0][0], x.matrix[0][1], x.matrix[0][2],
+                                          x.matrix[1][0], x.matrix[1][1], x.matrix[1][2],
+                                          x.matrix[2][0], x.matrix[2][1], x.matrix[2][2]))
+                    print(" Unprintability: \t{}".format(x.unprintability))
+
+                    print("Found result:    \t{:2f} s\n".format(time() - cstime))
+
+        if not args.result:
+            try:
+                fh.write_mesh(objs, info, outputfile, args.output_type)
+            except FileNotFoundError:
+                raise FileNotFoundError("Output File '{}' not found.".format(outputfile))
+
+        # Success message
+        if args.verbose:
+            print("Tweaking '{}' took:  \t{:2f} s".format(input_path.split(os.sep)[-1], time() - stime))
+            print("Successfully Rotated '{}'!".format(input_path.split(os.sep)[-1]))
+
+    stime_total = time()
     try:
         args = getargs()
         if args is None:
@@ -129,60 +216,39 @@ def cli():
     except:
         raise
 
+    # Expand input patterns (e.g. connector_V00*.stl) to a list of files
+    raw_input = args.inputfile
+    wildcard_chars = ["*", "?", "["]
+
+    has_wildcard = any(ch in raw_input for ch in wildcard_chars)
+
+    if has_wildcard:
+        input_files = sorted(glob.glob(raw_input))
+        if not input_files:
+            print("No input files match pattern: {}".format(raw_input))
+            sys.exit(1)
+        # If the input was given as a wildcard pattern and the user did NOT
+        # explicitly provide -o, ignore the automatically generated default
+        # output file so that per-file names are derived from each input_path.
+        if not getattr(args, "outputfile_given", False):
+            args.outputfile = None
+    else:
+        input_files = [raw_input]
+
+    # Disallow a single explicit output file when multiple inputs are given
+    if getattr(args, "outputfile_given", False) and len(input_files) > 1:
+        raise SystemExit("Option '-o' cannot be used with a wildcard that matches multiple input files.")
+
     try:
         FileHandler = FileHandler.FileHandler()
-        objs = FileHandler.load_mesh(args.inputfile)
-        if objs is None:
-            sys.exit()
-    except(KeyboardInterrupt, SystemExit):
-        raise SystemExit("Error, loading mesh from file failed!")
+    except (KeyboardInterrupt, SystemExit):
+        raise SystemExit("Error, initializing FileHandler failed!")
 
-    # Start of tweaking.
+    for input_path in input_files:
+        _process_single_file(input_path, args, FileHandler)
+
     if args.verbose:
-        print("Calculating the optimal orientation:\n  {}"
-              .format(args.inputfile.split(os.sep)[-1]))
-
-    c = 0
-    info = dict()
-    for part, content in objs.items():
-        mesh = content["mesh"]
-        info[part] = dict()
-        if args.convert:
-            info[part]["matrix"] = [[1, 0, 0], [0, 1, 0], [0, 0, 1]]
-        else:
-            try:
-                cstime = time()
-                x = Tweak(mesh, args.extended_mode, args.verbose, args.show_progress, args.favside, args.volume)
-                info[part]["matrix"] = x.matrix
-                info[part]["tweaker_stats"] = x
-            except (KeyboardInterrupt, SystemExit):
-                raise SystemExit("\nError, tweaking process failed!")
-
-            # List tweaking results
-            if args.result or args.verbose:
-                print("Result-stats:")
-                print(" Tweaked Z-axis: \t{}".format(x.alignment))
-                print(" Axis {}, \tangle: {}".format(x.rotation_axis, x.rotation_angle))
-                print(""" Rotation matrix: 
-            {:2f}\t{:2f}\t{:2f}
-            {:2f}\t{:2f}\t{:2f}
-            {:2f}\t{:2f}\t{:2f}""".format(x.matrix[0][0], x.matrix[0][1], x.matrix[0][2],
-                                          x.matrix[1][0], x.matrix[1][1], x.matrix[1][2],
-                                          x.matrix[2][0], x.matrix[2][1], x.matrix[2][2]))
-                print(" Unprintability: \t{}".format(x.unprintability))
-
-                print("Found result:    \t{:2f} s\n".format(time() - cstime))
-
-    if not args.result:
-        try:
-            FileHandler.write_mesh(objs, info, args.outputfile, args.output_type)
-        except FileNotFoundError:
-            raise FileNotFoundError("Output File '{}' not found.".format(args.outputfile))
-
-    # Success message
-    if args.verbose:
-        print("Tweaking took:  \t{:2f} s".format(time() - stime))
-        print("Successfully Rotated!")
+        print("Total tweaking time:  \t{:2f} s".format(time() - stime_total))
 
 if __name__ == "__main__":
     cli()

--- a/test_wildcard_cli.py
+++ b/test_wildcard_cli.py
@@ -1,0 +1,131 @@
+import os
+import runpy
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+
+TWEAKER_PATH = Path(__file__).resolve().parent / "Tweaker.py"
+
+
+def _install_stubs(monkeypatch, record):
+    # Stub MeshTweaker so importing Tweaker.py never pulls in the real numpy-heavy stack.
+    mesh_mod = types.ModuleType("MeshTweaker")
+
+    class Tweak:
+        def __init__(self, *args, **kwargs):
+            # Not used in convert mode (-c), but keep attributes in case tests change.
+            self.matrix = [[1, 0, 0], [0, 1, 0], [0, 0, 1]]
+            self.alignment = [0, 0, 1]
+            self.rotation_axis = [1, 0, 0]
+            self.rotation_angle = 0.0
+            self.unprintability = 0.0
+            self.euler_parameter = [self.rotation_axis, self.rotation_angle]
+            self.bottom_area = 0.0
+            self.overhang_area = 0.0
+            self.contour = 0.0
+            self.best_5 = []
+            self.time = 0.0
+
+    mesh_mod.Tweak = Tweak
+
+    # Stub FileHandler so no files are actually parsed/written.
+    fh_mod = types.ModuleType("FileHandler")
+
+    class FileHandler:
+        def __init__(self):
+            pass
+
+        def load_mesh(self, inputfile):
+            record["loaded"].append(inputfile)
+            # One "part" is enough for Tweaker.py's loops.
+            return {0: {"mesh": [0.0, 0.0, 0.0, 0.0, 0.0, 0.0], "name": "part0"}}
+
+        def write_mesh(self, objects, info, outputfile, output_type="binarystl"):
+            record["written"].append(
+                {"outputfile": outputfile, "output_type": output_type}
+            )
+
+    fh_mod.FileHandler = FileHandler
+
+    monkeypatch.setitem(sys.modules, "MeshTweaker", mesh_mod)
+    monkeypatch.setitem(sys.modules, "FileHandler", fh_mod)
+
+
+def _run_cli(tmp_path, argv, monkeypatch, record):
+    _install_stubs(monkeypatch, record)
+
+    old_cwd = os.getcwd()
+    old_argv = sys.argv[:]
+    os.chdir(tmp_path)
+    sys.argv = ["Tweaker.py", *argv]
+
+    try:
+        runpy.run_path(str(TWEAKER_PATH), run_name="__main__")
+        return None
+    except SystemExit as e:
+        return e
+    finally:
+        os.chdir(old_cwd)
+        sys.argv = old_argv
+
+
+def test_wildcard_expands_and_generates_per_file_outputs(tmp_path, monkeypatch):
+    (tmp_path / "input_a.stl").write_text("dummy")
+    (tmp_path / "input_b.stl").write_text("dummy")
+
+    record = {"loaded": [], "written": []}
+    exc = _run_cli(
+        tmp_path,
+        ["-i", "input_*.stl", "-c"],
+        monkeypatch,
+        record,
+    )
+    assert exc is None
+
+    assert record["loaded"] == ["input_a.stl", "input_b.stl"]
+    assert [c["outputfile"] for c in record["written"]] == [
+        "input_a_converted.stl",
+        "input_b_converted.stl",
+    ]
+
+
+def test_wildcard_no_matches_exits_with_message(tmp_path, monkeypatch, capsys):
+    record = {"loaded": [], "written": []}
+    exc = _run_cli(tmp_path, ["-i", "missing_*.stl", "-c"], monkeypatch, record)
+    assert exc is not None
+    assert exc.code == 1
+
+    out = capsys.readouterr().out
+    assert "No input files match pattern: missing_*.stl" in out
+
+
+def test_wildcard_with_explicit_o_multiple_inputs_errors(tmp_path, monkeypatch):
+    (tmp_path / "input_a.stl").write_text("dummy")
+    (tmp_path / "input_b.stl").write_text("dummy")
+
+    record = {"loaded": [], "written": []}
+    exc = _run_cli(
+        tmp_path,
+        ["-i", "input_*.stl", "-o", "out.stl", "-c"],
+        monkeypatch,
+        record,
+    )
+    assert exc is not None
+    assert str(exc) == "Option '-o' cannot be used with a wildcard that matches multiple input files."
+    assert record["loaded"] == []
+    assert record["written"] == []
+
+
+def test_single_file_no_wildcard_uses_single_outputfile(tmp_path, monkeypatch):
+    (tmp_path / "input_a.stl").write_text("dummy")
+
+    record = {"loaded": [], "written": []}
+    exc = _run_cli(tmp_path, ["-i", "input_a.stl", "-c"], monkeypatch, record)
+    assert exc is None
+
+    assert record["loaded"] == ["input_a.stl"]
+    assert [c["outputfile"] for c in record["written"]] == ["input_a_converted.stl"]
+


### PR DESCRIPTION
# Summary

This PR adds wildcard support to the CLI input parameter -i, so you can pass a wildcard pattern (e.g. file_V00*.stl) and Tweaker will expand it to multiple matching files and process them sequentially.

It also updates documentation to describe the new multi-file behavior and adds automated tests to verify:
* wildcard expansion works,
* wildcard patterns with no matches fail with the expected message and exit code,
* using -o with a wildcard that matches multiple inputs errors out,
* single-file input behavior is unchanged.

# Behavior changes

- -i now supports wildcard patterns and expands them via glob.
- If -i matches multiple files and -o is NOT provided, outputs are generated per input:
  - *_tweaked.stl by default
  - *_converted.stl when -c/--convert is set
- If -o IS provided and the wildcard matches multiple inputs, Tweaker exits with:
  - Option '-o' cannot be used with a wildcard that matches multiple input files.

# Tests

- Added test_wildcard_cli.py using stubbed MeshTweaker/FileHandler to validate CLI/wildcard logic without requiring real mesh files.
